### PR TITLE
Adding a tooltip to the manual

### DIFF
--- a/src/main/java/net/tardis/mod/common/items/ItemManual.java
+++ b/src/main/java/net/tardis/mod/common/items/ItemManual.java
@@ -8,7 +8,7 @@ public class ItemManual extends ItemBase {
 	
 	@Override
 	public void addInformation(ItemStack stack, World worldIn, List<String> tooltip, ITooltipFlag flagIn) {
-		tooltip.add(new TextComponentTranslation("item.manual"));
+		tooltip.add(new TextComponentTranslation("manual.help"));
 		super.addInformation(stack, worldIn, tooltip, flagIn);
 	}
 	

--- a/src/main/java/net/tardis/mod/common/items/ItemManual.java
+++ b/src/main/java/net/tardis/mod/common/items/ItemManual.java
@@ -8,7 +8,7 @@ public class ItemManual extends ItemBase {
 	
 	@Override
 	public void addInformation(ItemStack stack, World worldIn, List<String> tooltip, ITooltipFlag flagIn) {
-		tooltip.add(new TextComponentTranslation("key.manual"));
+		tooltip.add(new TextComponentTranslation("item.manual"));
 		super.addInformation(stack, worldIn, tooltip, flagIn);
 	}
 	

--- a/src/main/java/net/tardis/mod/common/items/ItemManual.java
+++ b/src/main/java/net/tardis/mod/common/items/ItemManual.java
@@ -5,5 +5,11 @@ public class ItemManual extends ItemBase {
 	public ItemManual() {
 		this.setMaxStackSize(1);
 	}
-
+	
+	@Override
+	public void addInformation(ItemStack stack, World worldIn, List<String> tooltip, ITooltipFlag flagIn) {
+		tooltip.add(new TextComponentTranslation("key.manual"));
+		super.addInformation(stack, worldIn, tooltip, flagIn);
+	}
+	
 }

--- a/src/main/resources/assets/tardis/lang/en_us.lang
+++ b/src/main/resources/assets/tardis/lang/en_us.lang
@@ -111,4 +111,6 @@ death.cyberman.generic=was converted
 key.notwheretardis=THIS IS NOT WHERE THE TARDIS IS!
 key.console.location=Console at: 
 
+manual.help=Right click on controls to learn about them.
+
 tardis.damage.demat=The Dematerialization Circuit has been fried!


### PR DESCRIPTION
I couldn't figure out how the manual worked. Maybe design choices shouldn't be designed around my level of intelligence but I feel like this might make the mod a little easier to get into.

So this pull request adds a tooltip to the manual explaining  its use.