### PR TITLE
Stops Client from overlapping waypoint message.

### DIFF
--- a/src/main/java/net/tardis/mod/common/entities/controls/ControlWaypoint.java
+++ b/src/main/java/net/tardis/mod/common/entities/controls/ControlWaypoint.java
@@ -41,8 +41,7 @@ public class ControlWaypoint extends EntityControl {
 				tardis.waypointIndex = 0;
 			if (tardis.waypointIndex < 0)
 				tardis.waypointIndex = tardis.saveCoords.size() - 1;
-			if(!world.isRemote)
-			player.sendStatusMessage(new TextComponentString("Waypoint " + (tardis.waypointIndex + 1) + ": " + tardis.saveCoords.get(tardis.waypointIndex).name), true);
+			PlayerHelper.sendMessage(player,"Waypoint " + (tardis.waypointIndex + 1) + ": " + tardis.saveCoords.get(tardis.waypointIndex).name, true);
 		}
 
 	}

--- a/src/main/java/net/tardis/mod/common/entities/controls/ControlWaypoint.java
+++ b/src/main/java/net/tardis/mod/common/entities/controls/ControlWaypoint.java
@@ -41,6 +41,7 @@ public class ControlWaypoint extends EntityControl {
 				tardis.waypointIndex = 0;
 			if (tardis.waypointIndex < 0)
 				tardis.waypointIndex = tardis.saveCoords.size() - 1;
+			if(!world.isRemote)
 			player.sendStatusMessage(new TextComponentString("Waypoint " + (tardis.waypointIndex + 1) + ": " + tardis.saveCoords.get(tardis.waypointIndex).name), true);
 		}
 


### PR DESCRIPTION
Client send a message of "None" when server had a waypoint which overlapped. This doesn't happen anymore now.